### PR TITLE
fix solution previewing

### DIFF
--- a/components/PreviewQuiz.tsx
+++ b/components/PreviewQuiz.tsx
@@ -69,36 +69,36 @@ export default function ShowQuiz({ quiz, profile, session }: PropTypes) {
 
   return (
     <>
-      <div className='max-w-4xl pt-20 mx-auto sm:px-6 lg:px-8'>
-        <div className='max-w-3xl mx-auto'>
-          <div className='flex justify-between px-4'>
-            <div className='flex flex-row'>
+      <div className="max-w-4xl pt-20 mx-auto sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex justify-between px-4">
+            <div className="flex flex-row">
               <img
                 src={profile.avatar_url}
-                alt='avatar'
-                className='w-12 h-12 mr-4 rounded-full'
+                alt="avatar"
+                className="w-12 h-12 mr-4 rounded-full"
               />
               <div>
                 <div>
-                  <p className='font-bold text-white text-md'>
+                  <p className="font-bold text-white text-md">
                     {profile.full_name}
                   </p>
                   <a
-                    className='text-sm font-bold text-gray-500'
+                    className="text-sm font-bold text-gray-500"
                     href={`https://www.twitter.com/${profile.username}`}
-                    target='_blank'
+                    target="_blank"
                   >
                     @{profile.username}
                   </a>
                 </div>
               </div>
             </div>
-            <div className='flex flex-col justify-end mx-8 text-sm text-gray-500'>
-              <p className='text-gray-200'>1337 views</p>
+            <div className="flex flex-col justify-end mx-8 text-sm text-gray-500">
+              <p className="text-gray-200">1337 views</p>
               {quiz.language}
             </div>
           </div>
-          <p className='max-w-md px-4 mx-auto mt-4 mb-12 text-base text-left text-white whitespace-pre-wrap sm:mt-12 md:mx-auto sm:text-lg md:mt-16 md:text-xl md:max-w-3xl'>
+          <p className="max-w-md px-4 mx-auto mt-4 mb-12 text-base text-left text-white whitespace-pre-wrap sm:mt-12 md:mx-auto sm:text-lg md:mt-16 md:text-xl md:max-w-3xl">
             {quiz.description}
           </p>
 
@@ -107,17 +107,17 @@ export default function ShowQuiz({ quiz, profile, session }: PropTypes) {
             runCode={runCode}
             hasCodeRun={hasCodeRun}
             output={output}
-            height='20rem'
+            height="20rem"
           />
 
-          <div className='px-4 pt-8 sm:px-0'>
+          <div className="px-4 pt-8 sm:px-0">
             <button
-              className='relative flex items-center px-4 py-2 text-sm font-medium text-white transition rounded-md font-ibm gradient-cta hover:scale-105 disabled:hover:scale-100 disabled:opacity-50'
+              className="relative flex items-center px-4 py-2 text-sm font-medium text-white transition rounded-md font-ibm gradient-cta hover:scale-105 disabled:hover:scale-100 disabled:opacity-50"
               onClick={runCode}
               disabled={codeRunning || tsLoading}
             >
               <Confetti active={success} config={confettiConfig} />
-              <span className='text-gray-100 transition duration-200 group-hover:text-gray-100'>
+              <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">
                 {tsLoading || codeRunning ? "Loading..." : "Run Code →"}
               </span>
             </button>
@@ -125,13 +125,13 @@ export default function ShowQuiz({ quiz, profile, session }: PropTypes) {
 
           {errors.length > 0 ? (
             <div>
-              <label className='block pt-8 pb-2 text-sm font-medium text-white'>
+              <label className="block pt-8 pb-2 text-sm font-medium text-white">
                 Errors
               </label>
-              <div className='p-4 bg-gray-300 rounded-md bg-opacity-20 max-w-max lg:bg-transparent'>
+              <div className="p-4 bg-gray-300 rounded-md bg-opacity-20 max-w-max lg:bg-transparent">
                 {errors.map((error, index) => (
                   <div key={index}>
-                    <p className='text-sm text-red-400'>{error}</p>
+                    <p className="text-sm text-red-400">{error}</p>
                   </div>
                 ))}
               </div>
@@ -139,19 +139,19 @@ export default function ShowQuiz({ quiz, profile, session }: PropTypes) {
           ) : null}
 
           <div>
-            <label className='block pt-8 pb-2 text-sm font-medium text-white'>
+            <label className="block pt-8 pb-2 text-sm font-medium text-white">
               Output
             </label>
 
-            <OutputEditor output={output} height='10rem' />
+            <OutputEditor output={output} height="10rem" />
           </div>
         </div>
       </div>
-      <div className='justify-end pt-5 mt-6 right-64'>
-        <div className='flex items-center justify-end space-x-4'>
+      <div className="justify-end pt-5 mt-6 right-64">
+        <div className="flex items-center justify-end space-x-4">
           <button
-            type='submit'
-            className='px-20 py-4 font-medium text-white transition gradient-cta rounded-xl focus:ring-2 focus:ring-white hover:scale-105 disabled:opacity-50'
+            type="submit"
+            className="px-20 py-4 font-medium text-white transition gradient-cta rounded-xl focus:ring-2 focus:ring-white hover:scale-105 disabled:opacity-50"
             disabled={!success}
             onClick={saveQuiz}
           >
@@ -160,9 +160,9 @@ export default function ShowQuiz({ quiz, profile, session }: PropTypes) {
         </div>
       </div>
       {createdUrl ? (
-        <span className='text-lg text-white'>
+        <span className="text-lg text-white">
           Quiz created successfully!{" "}
-          <a className='font-medium underline' href={createdUrl}>
+          <a className="font-medium underline" href={createdUrl}>
             {createdUrl}
           </a>
         </span>

--- a/components/RunCodeEditor.tsx
+++ b/components/RunCodeEditor.tsx
@@ -8,6 +8,7 @@ type PropTypes = {
   hasCodeRun: Boolean;
   output: Array<string>;
   height: string;
+  readOnly?: boolean;
 };
 
 export default function RunCodeEditor(props: PropTypes) {
@@ -37,19 +38,20 @@ export default function RunCodeEditor(props: PropTypes) {
     <div className={hasCodeRun && output.length === 0 ? "animate-shake" : null}>
       <Editor
         height={height}
-        defaultLanguage='typescript'
+        defaultLanguage="typescript"
         value={codeRef.current}
         onChange={(code: string) => {
           codeRef.current = code;
         }}
-        className='block text-white rounded-lg dark:border-purple-300 focus:ring-gray-500 sm:text-sm'
-        theme='vs-dark'
+        className="block text-white rounded-lg dark:border-purple-300 focus:ring-gray-500 sm:text-sm"
+        theme="vs-dark"
         options={{
           fontSize: 14,
           minimap: { enabled: false },
           overviewRulerLanes: 0,
           padding: { top: 15, bottom: 4, left: 4, right: 4 },
           renderLineHighlight: "none",
+          readOnly: props.readOnly,
         }}
         onMount={handleEditorDidMount}
       />

--- a/hooks/useForceUpdate.ts
+++ b/hooks/useForceUpdate.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from "react";
+
+type Updater = () => void;
+
+const useForceUpdate = (): Updater => {
+  const [_, setCount] = useState(0);
+
+  return useCallback(() => {
+    setCount((prev) => prev + 1);
+  }, [setCount]);
+};
+
+export default useForceUpdate;

--- a/hooks/useRunCode.ts
+++ b/hooks/useRunCode.ts
@@ -38,6 +38,6 @@ export default function useRunCode(
     output,
     errors,
     hasCodeRun,
-    success
-  }
+    success,
+  };
 }

--- a/pages/q/[id].tsx
+++ b/pages/q/[id].tsx
@@ -12,6 +12,7 @@ import { confettiConfig } from "../../utils/confettiConfig";
 import OutputEditor from "../../components/OutputEditor";
 import Footer from "../../components/Footer";
 import ViewCounter from "../../components/ViewCounter";
+import useForceUpdate from "../../hooks/useForceUpdate";
 
 export async function getServerSideProps({ params }) {
   const id: string = params.id;
@@ -58,112 +59,141 @@ type PropTypes = {
 export default function ShowQuiz({ quiz, profile }: PropTypes) {
   const { tsClient, tsLoading } = useTypescript();
   const [showSolution, setShowSolution] = useState(false);
+  const forceUpdate = useForceUpdate();
   let codeRef = useRef(quiz.start_code);
-  const { runCode, codeRunning, output, errors, hasCodeRun, success } =
-    useRunCode(tsClient, codeRef, quiz.target_output);
+  let solutionCodeRef = useRef(quiz.solution);
+  const userCodeInterpreter = useRunCode(tsClient, codeRef, quiz.target_output);
+  const solutionInterpreter = useRunCode(
+    tsClient,
+    solutionCodeRef,
+    quiz.target_output
+  );
 
-  function setSolution() {
-    setShowSolution(true);
-    codeRef.current = quiz.solution;
-  }
+  const activeInterpreter = showSolution
+    ? solutionInterpreter
+    : userCodeInterpreter;
 
   function resetCode() {
     codeRef.current = quiz.start_code;
+    forceUpdate();
   }
 
   return (
     <>
-      <div className='max-w-4xl pt-20 pb-48 mx-auto sm:px-6 lg:px-8'>
-        <div className='max-w-3xl mx-auto'>
-          <div className='flex justify-between px-4'>
-            <div className='flex flex-row'>
+      <div className="max-w-4xl pt-20 pb-48 mx-auto sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex justify-between px-4">
+            <div className="flex flex-row">
               <img
                 src={profile.avatar_url}
-                alt='avatar'
-                className='w-12 h-12 mr-4 rounded-full'
+                alt="avatar"
+                className="w-12 h-12 mr-4 rounded-full"
               />
               <div>
                 <div>
-                  <p className='font-bold text-white text-md'>
+                  <p className="font-bold text-white text-md">
                     {profile.full_name}
                   </p>
                   <a
-                    className='text-sm font-bold text-gray-500'
+                    className="text-sm font-bold text-gray-500"
                     href={`https://www.twitter.com/${profile.username}`}
-                    target='_blank'
+                    target="_blank"
                   >
                     @{profile.username}
                   </a>
                 </div>
               </div>
             </div>
-            <div className='flex flex-col justify-end mx-8 text-sm text-gray-500'>
-              <p className='text-gray-200'>{ViewCounter(parseInt(quiz.id))}</p>
+            <div className="flex flex-col justify-end mx-8 text-sm text-gray-500">
+              <p className="text-gray-200">{ViewCounter(parseInt(quiz.id))}</p>
               {quiz.language}
             </div>
           </div>
-          <p className='max-w-md px-4 mx-auto mt-4 mb-12 text-base text-left text-white whitespace-pre-wrap sm:mt-12 md:mx-auto sm:text-lg md:mt-16 md:text-xl md:max-w-3xl'>
+          <p className="max-w-md px-4 mx-auto mt-4 mb-12 text-base text-left text-white whitespace-pre-wrap sm:mt-12 md:mx-auto sm:text-lg md:mt-16 md:text-xl md:max-w-3xl">
             {quiz.description}
           </p>
-          <div className='flex justify-end mt-16 pt-18'>
+          <div className="flex justify-end mt-16 pt-18">
+            {!showSolution && (
+              <button
+                type="button"
+                className="px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-l border-gray-800 border-tl ml-2w-48 rounded-tl-md margin-auto hover:bg-gray-900"
+                onClick={resetCode}
+                title="Reset Code"
+              >
+                <RefreshIcon className="w-4 h-4" />
+              </button>
+            )}
             <button
-              type='button'
-              className='px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-l border-gray-800 border-tl ml-2w-48 rounded-tl-md margin-auto hover:bg-opacity-100'
-              onClick={resetCode}
+              type="button"
+              className="px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-r border-gray-800 border-tr ml-2w-48 rounded-tr-md margin-auto hover:bg-gray-900"
+              onClick={() => setShowSolution((prev) => !prev)}
             >
-              <RefreshIcon className='w-4 h-4' />
-            </button>
-            <button
-              type='button'
-              className='px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-r border-gray-800 border-tr ml-2w-48 rounded-tr-md margin-auto hover:bg-opacity-100'
-              onClick={() => setSolution()}
-            >
-              Show Solution
+              {showSolution ? (
+                <span>Hide Solution</span>
+              ) : (
+                <span>Show Solution</span>
+              )}
             </button>
           </div>
 
-          <RunCodeEditor
-            codeRef={codeRef}
-            runCode={runCode}
-            hasCodeRun={hasCodeRun}
-            output={output}
-            height='20rem'
-          />
-
-          <div className='px-4 pt-8 sm:px-0'>
+          {showSolution && (
+            <RunCodeEditor
+              codeRef={solutionCodeRef}
+              runCode={solutionInterpreter.runCode}
+              hasCodeRun={solutionInterpreter.hasCodeRun}
+              output={solutionInterpreter.output}
+              height="20rem"
+              readOnly
+            />
+          )}
+          {!showSolution && (
+            <RunCodeEditor
+              codeRef={codeRef}
+              runCode={userCodeInterpreter.runCode}
+              hasCodeRun={userCodeInterpreter.hasCodeRun}
+              output={userCodeInterpreter.output}
+              height="20rem"
+            />
+          )}
+          <div className="px-4 pt-8 sm:px-0">
             <button
-              className='relative flex items-center px-4 py-2 text-sm font-medium text-white transition rounded-md font-ibm gradient-cta hover:scale-105 disabled:hover:scale-100 disabled:opacity-50'
-              onClick={runCode}
-              disabled={codeRunning || tsLoading}
+              className="relative flex items-center px-4 py-2 text-sm font-medium text-white transition rounded-md font-ibm gradient-cta hover:scale-105 disabled:hover:scale-100 disabled:opacity-50"
+              onClick={activeInterpreter.runCode}
+              disabled={activeInterpreter.codeRunning || tsLoading}
             >
-              <Confetti active={success} config={confettiConfig} />
-              <span className='text-gray-100 transition duration-200 group-hover:text-gray-100'>
-                {tsLoading || codeRunning ? "Loading..." : "Run Code →"}
+              <Confetti
+                active={activeInterpreter.success}
+                config={confettiConfig}
+              />
+              <span className="text-gray-100 transition duration-200 group-hover:text-gray-100">
+                {tsLoading || activeInterpreter.codeRunning
+                  ? "Loading..."
+                  : "Run Code →"}
               </span>
             </button>
           </div>
 
-          {errors.length > 0 ? (
+          {activeInterpreter.errors.length && (
             <div>
-              <label className='block pt-8 pb-2 text-sm font-medium text-white'>
+              <label className="block pt-8 pb-2 text-sm font-medium text-white">
                 Errors
               </label>
-              <div className='p-4 bg-gray-300 rounded-md bg-opacity-20 max-w-max lg:bg-transparent'>
-                {errors.map((error, index) => (
+              <div className="p-4 bg-gray-300 rounded-md bg-opacity-20 max-w-max lg:bg-transparent">
+                {activeInterpreter.errors.map((error, index) => (
                   <div key={index}>
-                    <p className='text-sm text-red-400'>{error}</p>
+                    <p className="text-sm text-red-400">{error}</p>
                   </div>
                 ))}
               </div>
             </div>
-          ) : null}
+          )}
 
           <div>
-            <label className='block pt-8 pb-2 text-sm font-medium text-white'>
+            <label className="block pt-8 pb-2 text-sm font-medium text-white">
               Output
             </label>
 
-            <OutputEditor output={output} height='10rem' />
+            <OutputEditor output={activeInterpreter.output} height="10rem" />
           </div>
         </div>
       </div>

--- a/pages/q/[id].tsx
+++ b/pages/q/[id].tsx
@@ -123,17 +123,19 @@ export default function ShowQuiz({ quiz, profile }: PropTypes) {
                 <RefreshIcon className="w-4 h-4" />
               </button>
             )}
-            <button
-              type="button"
-              className="px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-r border-gray-800 border-tr ml-2w-48 rounded-tr-md margin-auto hover:bg-gray-900"
-              onClick={() => setShowSolution((prev) => !prev)}
-            >
-              {showSolution ? (
-                <span>Hide Solution</span>
-              ) : (
-                <span>Show Solution</span>
-              )}
-            </button>
+            {quiz.solution && (
+              <button
+                type="button"
+                className="px-2 py-2 text-xs font-medium text-center text-white transition bg-black bg-opacity-25 border-r border-gray-800 border-tr ml-2w-48 rounded-tr-md margin-auto hover:bg-gray-900"
+                onClick={() => setShowSolution((prev) => !prev)}
+              >
+                {showSolution ? (
+                  <span>Hide Solution</span>
+                ) : (
+                  <span>Show Solution</span>
+                )}
+              </button>
+            )}
           </div>
 
           {showSolution && (

--- a/schema.sql
+++ b/schema.sql
@@ -2,22 +2,6 @@ create extension if not exists "moddatetime" with schema "extensions" version '1
 
 create type "public"."language" as enum ('typescript');
 
-alter table "public"."quizzes" add column "views" bigint default '0'::bigint;
-
-
-CREATE OR REPLACE FUNCTION public.increment(x integer, row_id integer)
- RETURNS integer
- LANGUAGE sql
- SECURITY DEFINER
-AS $function$
-  update quizzes 
-  set views = views + x
-  where id = row_id;
-
-  select views from quizzes where id = row_id ;
-$function$
-;
-
 create table "public"."profiles" (
     "id" uuid not null,
     "created_at" timestamp with time zone not null,
@@ -42,6 +26,19 @@ create table "public"."quizzes" (
     "friendly_id" character varying
 );
 
+alter table "public"."quizzes" add column "views" bigint default '0'::bigint;
+CREATE OR REPLACE FUNCTION public.increment(x integer, row_id integer)
+ RETURNS integer
+ LANGUAGE sql
+ SECURITY DEFINER
+AS $function$
+  update quizzes 
+  set views = views + x
+  where id = row_id;
+
+  select views from quizzes where id = row_id ;
+$function$
+;
 
 alter table "public"."quizzes" enable row level security;
 
@@ -285,3 +282,4 @@ CREATE TRIGGER create_profile_on_signup AFTER INSERT ON auth.users FOR EACH ROW 
 CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.quizzes FOR EACH ROW EXECUTE FUNCTION moddatetime('updated_at');
 
 
+alter table "public"."quizzes" add column "solution" character varying;


### PR DESCRIPTION
PRing against the include-solution branch so can see diff between the two branches better. 

This modifies the sql script to init the db because it was a bit broken/out of date (ideally should use migration for this, but probably ok in this case).

Because we're adding a solution column to the quizzes table, any existing rows will have null solutions. For these quizzes with no solution the "Show Solution" button is not rendered.

This also fixes solution previewing and makes solutions readonly. The use of refs here is a bit unconventional and in some cases is causing ui to get out of sync with the app state. The simplest fix was to put in a force rerender while reseting the code to its starting state. Ideally, should just use state instead of refs to store code and won't run into these out-of-sync bugs.
